### PR TITLE
feat: RFC 7807 Problem Details Validation Error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./dynamic-pricing
     steps:
     - uses: actions/checkout@v4
     - name: Build Docker image
-      run: docker build -t interview-app .
+      run: ./build.sh
     - name: Run the container
-      run: docker run -d -p 3000:3000 -v $(pwd):/rails --name interview-dev interview-app
+      run: ./dev.sh
     - name: Run all tests
-      run: docker container exec interview-dev ./bin/rails test
+      run: ./test.sh
     - name: Test API endpoint returns 200
       run: |
         echo "Testing API endpoint..."

--- a/dynamic-pricing/app/controllers/pricing_controller.rb
+++ b/dynamic-pricing/app/controllers/pricing_controller.rb
@@ -1,8 +1,11 @@
-class PricingController < ApplicationController
-  VALID_PERIODS = %w[Summer Autumn Winter Spring].freeze
-  VALID_HOTELS = %w[FloatingPointResort GitawayHotel RecursionRetreat].freeze
-  VALID_ROOMS = %w[SingletonRoom BooleanTwin RestfulKing].freeze
+# frozen_string_literal: true
 
+# The "frozen_string_literal" magic comment is a common Ruby optimization that makes all string
+# literals in this file immutable (similar in spirit to using readonly string constants in C#.
+# It is safe to include and does not change runtime behavior of this class.
+require 'set'
+
+class PricingController < ApplicationController
   before_action :validate_params
 
   def index
@@ -17,22 +20,65 @@ class PricingController < ApplicationController
   private
 
   def validate_params
-    # Validate required parameters
-    unless params[:period].present? && params[:hotel].present? && params[:room].present?
-      return render json: { error: "Missing required parameters: period, hotel, room" }, status: :bad_request
+    if (error = PricingValidation.validate(params, instance: request.path, trace_id: request.request_id))
+      return render json: error[:json], status: error[:status]
+    end
+  end
+end
+
+# Module for validating pricing parameters
+# Pricing API requires the following parameters: period, hotel, room
+# Each of these parameters has a set of allowed values
+# When validation fails, an RFC 7807 Problem Details object is returned
+module PricingValidation
+  module_function
+
+  # Use frozen Sets for O(1) membership checks and allocate them once at load time.
+  # Keep small source arrays only to build human-readable error strings once (no per-request joins).
+  PERIODS_LIST = %w[Summer Autumn Winter Spring].freeze
+  VALID_PERIODS = PERIODS_LIST.to_set.freeze
+  PERIODS_CSV = PERIODS_LIST.join(', ').freeze
+
+  HOTELS_LIST = %w[FloatingPointResort GitawayHotel RecursionRetreat].freeze
+  VALID_HOTELS = HOTELS_LIST.to_set.freeze
+  HOTELS_CSV = HOTELS_LIST.join(', ').freeze
+
+  ROOMS_LIST = %w[SingletonRoom BooleanTwin RestfulKing].freeze
+  VALID_ROOMS = ROOMS_LIST.to_set.freeze
+  ROOMS_CSV = ROOMS_LIST.join(', ').freeze
+
+  # Validates the incoming params for the pricing endpoint and returns either:
+  # - nil (no validation errors), or
+  # - { json: <problem details hash>, status: :bad_request }
+  #
+  # Implementation notes:
+  # - We accumulate errors per-field so clients can render them inline.
+  # - We use Sets above for O(1) membership checks (faster than array include? O(N)).
+  # - We precompute CSV lists for friendly error messages without per-request joins.
+  def validate(params, instance:, trace_id:)
+    errors = {}
+
+    if (messages = ValidationHelpers.validate_set_value_field(value: params[:period], field_key: 'period', field_label: 'period', allowed_set: VALID_PERIODS, allowed_csv: PERIODS_CSV))
+      errors['period'] = messages
     end
 
-    # Validate parameter values
-    unless VALID_PERIODS.include?(params[:period])
-      return render json: { error: "Invalid period. Must be one of: #{VALID_PERIODS.join(', ')}" }, status: :bad_request
+    if (messages = ValidationHelpers.validate_set_value_field(value: params[:hotel], field_key: 'hotel', field_label: 'hotel', allowed_set: VALID_HOTELS, allowed_csv: HOTELS_CSV))
+      errors['hotel'] = messages
     end
 
-    unless VALID_HOTELS.include?(params[:hotel])
-      return render json: { error: "Invalid hotel. Must be one of: #{VALID_HOTELS.join(', ')}" }, status: :bad_request
+    if (messages = ValidationHelpers.validate_set_value_field(value: params[:room], field_key: 'room', field_label: 'room', allowed_set: VALID_ROOMS, allowed_csv: ROOMS_CSV))
+      errors['room'] = messages
     end
 
-    unless VALID_ROOMS.include?(params[:room])
-      return render json: { error: "Invalid room. Must be one of: #{VALID_ROOMS.join(', ')}" }, status: :bad_request
-    end
+    return nil if errors.empty?
+
+    problem = ValidationProblem.build_validation_error(
+      errors: errors,
+      status: 400,
+      instance: instance,
+      trace_id: trace_id
+    )
+
+    { json: problem, status: :bad_request }
   end
 end

--- a/dynamic-pricing/app/services/validation_helpers.rb
+++ b/dynamic-pricing/app/services/validation_helpers.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Generic validation helpers reused across controllers/services.
+#
+# Conventions:
+# - Presence is checked first; if missing, return a single message in an array.
+# - If present, membership (or other constraints) are validated next.
+# - Return an array of error messages when invalid, or nil when valid.
+module ValidationHelpers
+  module_function
+
+  # Validates that a field is present and its value is contained in the allowed_set.
+  # Returns ["error message"] or nil.
+  def validate_set_value_field(value:, field_key:, field_label:, allowed_set:, allowed_csv:)
+    unless value.present?
+      return ["The #{field_label} field is required."]
+    end
+
+    unless allowed_set.include?(value)
+      return ["The #{field_label} field must be one of: #{allowed_csv}."]
+    end
+
+    nil
+  end
+end
+
+

--- a/dynamic-pricing/app/services/validation_problem.rb
+++ b/dynamic-pricing/app/services/validation_problem.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Build a standard RFC 7807 Problem Details object for validation failures.
+# See: https://datatracker.ietf.org/doc/html/rfc7807#section-3
+#
+# This creates a JSON-serializable Hash shaped like:
+# {
+#   "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+#   "title": "One or more validation errors occurred.",
+#   "status": 400,
+#   "traceId": "...optional trace id...",
+#   "instance": "/path/of/request",
+#   "errors": {
+#     "fieldName": ["message1", "message2"]
+#   }
+# }
+#
+# Notes:
+# - We default the RFC 7231 400 reference into `type` for client error semantics, matching
+#   common conventions for validation failures.
+# - `errors` is a map of field name -> array of human-readable messages.
+# - The hash is intentionally not frozen so Rails can safely serialize it.
+module ValidationProblem
+  module_function
+
+  DEFAULT_TYPE_FOR_400 = 'https://tools.ietf.org/html/rfc7231#section-6.5.1'.freeze
+  DEFAULT_VALIDATION_TITLE = 'One or more validation errors occurred.'.freeze
+
+  def build_validation_error(errors:, status: 400, title: DEFAULT_VALIDATION_TITLE, type: DEFAULT_TYPE_FOR_400, instance: nil, trace_id: nil)
+    problem = {
+      type: type,
+      title: title,
+      status: status,
+      errors: errors
+    }
+
+    problem[:instance] = instance if instance
+    problem[:traceId] = trace_id if trace_id
+
+    problem
+  end
+end

--- a/dynamic-pricing/config/application.rb
+++ b/dynamic-pricing/config/application.rb
@@ -36,6 +36,10 @@ module Interview
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
+    # Ensure service objects under app/services are autoloaded/eager loaded by Zeitwerk.
+    config.autoload_paths << Rails.root.join("app/services")
+    config.eager_load_paths << Rails.root.join("app/services")
+
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.

--- a/dynamic-pricing/test/controllers/pricing_controller_test.rb
+++ b/dynamic-pricing/test/controllers/pricing_controller_test.rb
@@ -22,7 +22,12 @@ class PricingControllerTest < ActionDispatch::IntegrationTest
     assert_equal "application/json", @response.media_type
 
     json_response = JSON.parse(@response.body)
-    assert_includes json_response["error"], "Missing required parameters"
+    assert_equal 400, json_response["status"]
+    assert_equal "One or more validation errors occurred.", json_response["title"]
+    assert json_response.key?("errors")
+    assert_equal ["The period field is required."], json_response["errors"]["period"]
+    assert_equal ["The hotel field is required."], json_response["errors"]["hotel"]
+    assert_equal ["The room field is required."], json_response["errors"]["room"]
   end
 
   test "should handle empty parameters" do
@@ -36,7 +41,11 @@ class PricingControllerTest < ActionDispatch::IntegrationTest
     assert_equal "application/json", @response.media_type
 
     json_response = JSON.parse(@response.body)
-    assert_includes json_response["error"], "Missing required parameters"
+    assert_equal 400, json_response["status"]
+    assert json_response.key?("errors")
+    assert_equal ["The period field is required."], json_response["errors"]["period"]
+    assert_equal ["The hotel field is required."], json_response["errors"]["hotel"]
+    assert_equal ["The room field is required."], json_response["errors"]["room"]
   end
 
   test "should reject invalid period" do
@@ -50,7 +59,10 @@ class PricingControllerTest < ActionDispatch::IntegrationTest
     assert_equal "application/json", @response.media_type
 
     json_response = JSON.parse(@response.body)
-    assert_includes json_response["error"], "Invalid period"
+    assert_equal 400, json_response["status"]
+    assert_equal ["The period field must be one of: Summer, Autumn, Winter, Spring."], json_response["errors"]["period"]
+    assert_not json_response["errors"].key?("hotel"), "Expected only period to have errors"
+    assert_not json_response["errors"].key?("room"), "Expected only period to have errors"
   end
 
   test "should reject invalid hotel" do
@@ -64,7 +76,10 @@ class PricingControllerTest < ActionDispatch::IntegrationTest
     assert_equal "application/json", @response.media_type
 
     json_response = JSON.parse(@response.body)
-    assert_includes json_response["error"], "Invalid hotel"
+    assert_equal 400, json_response["status"]
+    assert_equal ["The hotel field must be one of: FloatingPointResort, GitawayHotel, RecursionRetreat."], json_response["errors"]["hotel"]
+    assert_not json_response["errors"].key?("period"), "Expected only hotel to have errors"
+    assert_not json_response["errors"].key?("room"), "Expected only hotel to have errors"
   end
 
   test "should reject invalid room" do
@@ -78,6 +93,9 @@ class PricingControllerTest < ActionDispatch::IntegrationTest
     assert_equal "application/json", @response.media_type
 
     json_response = JSON.parse(@response.body)
-    assert_includes json_response["error"], "Invalid room"
+    assert_equal 400, json_response["status"]
+    assert_equal ["The room field must be one of: SingletonRoom, BooleanTwin, RestfulKing."], json_response["errors"]["room"]
+    assert_not json_response["errors"].key?("period"), "Expected only room to have errors"
+    assert_not json_response["errors"].key?("hotel"), "Expected only room to have errors"
   end
 end

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,1 @@
+docker exec -it dynamic-pricing-proxy ./bin/rails test


### PR DESCRIPTION
### TL;DR

Improved API validation with RFC 7807 Problem Details format and optimized CI workflow scripts.

### What changed?

- Refactored the validation logic in `PricingController` into separate modules:
  - Created `PricingValidation` module for parameter validation
  - Added `ValidationHelpers` for reusable validation functions
  - Added `ValidationProblem` to generate RFC 7807 compliant error responses
- Optimized validation with Sets for O(1) lookups instead of array scans
- Updated error responses to return structured field-level validation errors
- Simplified CI workflow by replacing inline Docker commands with shell scripts
- Added autoloading for the services directory in Rails configuration
- Updated tests to verify the new error response format

### How to test?

1. Run the test suite with `./test.sh`
2. Test the API with invalid parameters to verify the new error format:
   ```
   curl -v "http://localhost:3000/pricing?period=Invalid&hotel=GitawayHotel&room=RestfulKing"
   ```
3. Verify CI workflow by pushing to a branch and checking the GitHub Actions results

### Why make this change?

- Improves API error responses with a standardized format (RFC 7807) that provides better client-side error handling
- Enhances maintainability by separating validation logic into reusable modules
- Optimizes performance with Set-based validation instead of array scans
- Simplifies CI workflow with executable scripts instead of inline commands
- Provides more detailed validation feedback to API consumers with field-specific error messages