### PR TITLE
fix: input device in github action is not tty

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,1 +1,1 @@
-docker exec -it dynamic-pricing-proxy ./bin/rails test
+docker exec dynamic-pricing-proxy ./bin/rails test


### PR DESCRIPTION
### TL;DR

Removed the `-it` flag from the Docker exec command in the test script.

### What changed?

Modified `test.sh` to remove the interactive terminal flags (`-it`) when executing Rails tests in the Docker container. The command now uses `docker exec dynamic-pricing-proxy ./bin/rails test` instead of `docker exec -it dynamic-pricing-proxy ./bin/rails test`.

### How to test?

1. Run `./test.sh` to execute tests in the dynamic-pricing-proxy container
2. Verify that tests run successfully without requiring an interactive terminal

### Why make this change?

The `-it` flags (interactive and allocate TTY) are unnecessary for automated test execution and can cause issues in CI/CD environments where no TTY is available. This change makes the test script more compatible with automated environments while maintaining the same functionality.