### PR TITLE
feat: connect web api to redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,9 @@ services:
       - "3000:3000"
     volumes:
       - ./dynamic-pricing:/rails
+    environment:
+      - REDIS_URL=redis://valkey:6379/1
+      - RATE_API_URL=http://rate-api:8080
     depends_on:
       - rate-api
       - valkey

--- a/dynamic-pricing/Gemfile.lock
+++ b/dynamic-pricing/Gemfile.lock
@@ -132,9 +132,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
-    nokogiri (1.18.9-aarch64-linux-musl)
+    nokogiri (1.18.10-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.9-arm64-darwin)
+    nokogiri (1.18.10-arm64-darwin)
       racc (~> 1.4)
     pp (0.6.2)
       prettyprint

--- a/dynamic-pricing/app/controllers/healthz_controller.rb
+++ b/dynamic-pricing/app/controllers/healthz_controller.rb
@@ -1,5 +1,18 @@
 class HealthzController < ApplicationController
     def index
-        render json: { status: "ok" }
+        redis_ok = false
+        begin
+            redis_ok = RedisRepository.instance.ping() == "PONG"
+        rescue => e
+            puts "Error pinging Redis: #{e}"
+            redis_ok = false
+        end
+
+        render json: {
+            status: "ok",
+            redis: {
+                ok: redis_ok
+            }
+        }
     end
 end

--- a/dynamic-pricing/app/services/redis_repository.rb
+++ b/dynamic-pricing/app/services/redis_repository.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "redis"
+
+# A singleton for accessing the Redis key-value store, implementing the repository pattern
+class RedisRepository
+    # gets the singleton instance
+    def self.instance()
+        @instance ||= new()
+    end
+
+    # private constructor
+    private_class_method :new
+
+    # Ping the Redis server
+    def ping()
+        @client.ping();
+    end
+
+    # constructor
+    private
+    def initialize()
+        @client = Redis.new(url: ENV.fetch("REDIS_URL", "redis://localhost:6379/1"))
+    end
+end


### PR DESCRIPTION
### TL;DR

Added Redis connectivity to the dynamic pricing service with health check integration.

### What changed?

- Added Redis environment variables to the Rails service in `docker-compose.yml`
- Created a new `RedisRepository` singleton class to manage Redis connections
- Enhanced the health check endpoint to verify Redis connectivity
- Updated the Nokogiri gem from 1.18.9 to 1.18.10

### How to test?

1. Start the application with `docker-compose up`
2. Access the health check endpoint at `/healthz`
3. Verify the response includes Redis status information
4. Try disconnecting Redis to confirm the health check properly reports the failure

### Why make this change?

This change establishes Redis connectivity for the dynamic pricing service, which will be used for caching and data storage. The enhanced health check provides better observability by verifying that the Redis connection is working properly, making it easier to diagnose issues in the application's dependencies.