### PR TITLE
feat: AppSettings API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,10 @@ services:
     volumes:
       - ./dynamic-pricing:/rails
     environment:
-      - REDIS_URL=redis://valkey:6379/1
+      - REDIS_URL=redis://valkey:6379/0
       - RATE_API_URL=http://rate-api:8080
+      - RATE_API_TOKEN=04aa6f42aa03f220c2ae9a276cd68c62 # this is just a simulation
+      - RATE_API_QUOTA=1000
     depends_on:
       - rate-api
       - valkey

--- a/dynamic-pricing/app/services/app_settings.rb
+++ b/dynamic-pricing/app/services/app_settings.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# A strongly-typed module for accessing environment variables safely
+# It will log an error and throw an error if the environment variable is not set
+module AppSettings
+    module_function
+
+    def redis_url
+        require_env!("REDIS_URL")
+    end
+
+    def rate_api_url
+        require_env!("RATE_API_URL")
+    end
+
+    def rate_api_token
+        require_env!("RATE_API_TOKEN")
+    end
+
+    def rate_api_quota
+        quota = require_env!("RATE_API_QUOTA")
+        quota.to_i
+    end
+
+    # Reads env var, logs error if missing/blank, then raises
+    def require_env!(key)
+        value = ENV[key]
+        if value.nil? || value.strip.empty?
+            Rails.logger.error("Missing required environment variable: #{key}")
+            raise "Missing required environment variable: #{key}"
+        end
+        value
+    end
+end


### PR DESCRIPTION
### TL;DR

Added a strongly-typed AppSettings module for safely accessing environment variables and updated Redis database index.

### What changed?

- Created a new `AppSettings` module in `app/services/app_settings.rb` that provides type-safe access to environment variables
- Changed Redis database index from 1 to 0 in docker-compose.yml
- Added new environment variables for Rate API: `RATE_API_TOKEN` and `RATE_API_QUOTA`

### How to test?

1. Run the application with `docker-compose up`
2. Verify the application connects to Redis using database 0
3. Test that the application can access the Rate API with the provided token
4. Try removing an environment variable to confirm the error handling works as expected

### Why make this change?

This change improves application reliability by:
- Providing a centralized, type-safe way to access environment variables
- Adding proper error handling for missing environment variables
- Ensuring the Rate API integration has proper authentication and quota management