### PR TITLE
feat: Rate API Service

### DIFF
--- a/dynamic-pricing/app/controllers/healthz_controller.rb
+++ b/dynamic-pricing/app/controllers/healthz_controller.rb
@@ -1,17 +1,16 @@
 class HealthzController < ApplicationController
     def index
-        redis_ok = false
-        begin
-            redis_ok = RedisRepository.instance.ping() == "PONG"
-        rescue => e
-            puts "Error pinging Redis: #{e}"
-            redis_ok = false
-        end
-
         render json: {
             status: "ok",
             redis: {
-                ok: redis_ok
+                ok: RedisRepository.instance.ping()
+            },
+            metrics: {
+                quota: AppSettings.rate_api_quota,
+                rate_api_calls_used: RateApiService.get_api_call_count,
+                rate_api_calls_remaining: RateApiService.remaining_quota,
+                has_quota_remaining: RateApiService.has_quota_remaining?,
+                hit_count: RateApiService.get_hit_count
             }
         }
     end

--- a/dynamic-pricing/app/services/rate_api_client.rb
+++ b/dynamic-pricing/app/services/rate_api_client.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'uri'
+require 'json'
+
+# Lightweight client for the external Rate API
+# Supports both single and batch requests. The API accepts arrays of request objects
+# for efficient batch processing of multiple rate queries.
+#
+# All methods will never raise exceptions.
+# They will always return safe defaults (nil or empty hash) with proper logging.
+#
+# API Response Format Expected:
+# {
+#   "rates": [
+#     {
+#       "period": "Summer",
+#       "hotel": "FloatingPointResort",
+#       "room": "SingletonRoom",
+#       "rate": "12000"
+#     }
+#   ]
+# }
+#
+# Return formats:
+# - fetch_rate: Returns a single rate value (Integer or String) or nil if not found
+# - fetch_rates: Returns nested dictionary: rates[period][hotel][room] = rate_value or {} if error
+class RateApiClient
+    DEFAULT_TIMEOUT_SECONDS = 30
+
+    def initialize(base_url: AppSettings.rate_api_url, timeout_seconds: DEFAULT_TIMEOUT_SECONDS)
+        @base_url = base_url
+        @timeout_seconds = timeout_seconds
+    end
+
+    # Fetch rate values for multiple requests. Returns nested dictionary of rates.
+    # If unable to fetch rates, it will return an empty hash.
+    # @param requests [Array<Hash>] Array of request objects with period:, hotel:, room: keys
+    # @return [Hash] Nested dictionary: rates[period][hotel][room] = rate_value or {} if error
+    def fetch_rates(requests)
+        begin
+            uri = build_post_uri()
+            http = Net::HTTP.new(uri.host, uri.port)
+            http.open_timeout = @timeout_seconds
+            http.read_timeout = @timeout_seconds
+
+            request = Net::HTTP::Post.new(uri.request_uri)
+            request['Content-Type'] = 'application/json'
+            request['token'] = AppSettings.rate_api_token
+            request.body = JSON.generate({ attributes: requests })
+
+            response = http.request(request)
+
+            unless response.is_a?(Net::HTTPSuccess)
+                Rails.logger.warn "Rate API HTTP error: #{response.code} #{response.body}"
+                return {}
+            end
+
+            parse_rates(response.body, requests.length)
+        rescue StandardError => e
+            Rails.logger.warn "Rate API client error: #{e.message}"
+            return {}
+        end
+    end
+
+    # Fetch rate value for given attributes. Returns Integer or String depending on backend.
+    #
+    # This method utilizes fetch_rates internally to leverage the API's batch processing capability.
+    # Even for single requests, this ensures consistency and allows for potential future optimizations
+    # where single requests can be batched together if called in rapid succession.
+    #
+    # Returns nil if rate cannot be fetched.
+    def fetch_rate(period:, hotel:, room:)
+        requests = [{ period: period, hotel: hotel, room: room }]
+        rates_dict = fetch_rates(requests)
+
+        # Extract the specific rate from the nested dictionary
+        if rates_dict.key?(period) &&
+           rates_dict[period].key?(hotel) &&
+           rates_dict[period][hotel].key?(room)
+            return rates_dict[period][hotel][room]
+        end
+
+        # Rate not found in expected structure - return nil safely
+        Rails.logger.warn "Rate not found for #{period}/#{hotel}/#{room}"
+        nil
+    end
+
+    private
+
+    # Builds the URI for the POST request.
+    # @return [URI] The URI for the POST request
+    def build_post_uri()
+        uri = URI.parse(@base_url)
+        uri.path = File.join(uri.path.empty? ? '/' : uri.path, 'pricing')
+        uri
+    end
+
+    # Parses the API response and returns a nested dictionary of rates.
+    # If unable to parse the response, it will return an empty hash.
+    # @param body [String] The API response body
+    # @param expected_count [Integer] The expected number of rates
+    # @return [Hash] Nested dictionary: rates[period][hotel][room] = rate_value or {} if error
+    def parse_rates(body, expected_count)
+        begin
+            parsed = JSON.parse(body)
+        rescue JSON::ParserError
+            Rails.logger.warn "Failed to parse API response JSON"
+            return {}
+        end
+
+        # Handle different response formats for multiple rates
+        if parsed.is_a?(Hash) && parsed['rates'].is_a?(Array)
+            rates = parsed['rates']
+        else
+            Rails.logger.warn "Unexpected API response format: #{parsed.class}"
+            return {}
+        end
+
+        # Build nested dictionary structure: rates[period][hotel][room] = rate
+        result = {}
+        rates.each do |item|
+            if item.is_a?(Hash) && item.key?('rate') && item.key?('period') && item.key?('hotel') && item.key?('room')
+                period = item['period']
+                hotel = item['hotel']
+                room = item['room']
+                rate = item['rate']
+
+                # Initialize nested structure
+                result[period] ||= {}
+                result[period][hotel] ||= {}
+                result[period][hotel][room] = rate
+            else
+                Rails.logger.warn "Malformed rate item: #{item.inspect}"
+                # Skip malformed items, continue processing
+            end
+        end
+
+        result
+    end
+end
+
+

--- a/dynamic-pricing/app/services/rate_api_service.rb
+++ b/dynamic-pricing/app/services/rate_api_service.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Service for handling rate API calls with cache stampede prevention
+class RateApiService
+  # Fetch rate with cache stampede prevention
+  #
+  # @param period [String] The period (Summer, Autumn, Winter, Spring)
+  # @param hotel [String] The hotel name
+  # @param room [String] The room type
+  # @return [String] The rate value as a string
+  def self.get_rate(period:, hotel:, room:)
+    key = get_hotel_room_query_key(period: period, hotel: hotel, room: room)
+
+    repo = RedisRepository.instance
+
+    # First, try to get the cached value without locking
+    if (cached = repo.get(key))
+      return JSON.parse(cached)
+    end
+
+    if !has_quota_remaining?
+      Rails.logger.warn "No quota remaining when attempting to fetch rate for #{key}"
+      raise ServiceUnavailableError.new("Service temporarily unavailable. No quota remaining.")
+    end
+
+    # Cache miss: use distributed lock to prevent stampede
+    # Use the cache key as the lock resource to ensure per-key locking
+    lock_resource = repo.get_lock_key(key)
+    # Set lock TTL to 30 seconds (should be enough for API call + processing)
+    # This prevents deadlocks if the process crashes during cache regeneration
+
+    result = repo.with_lock(lock_resource, ttl_milliseconds: 30_000, retry_count: 2) do
+      # Double-checked locking: check cache again inside the lock
+      # in case another process already regenerated it while we waited
+      if (cached = repo.get(key))
+        JSON.parse(cached)
+      else
+        # We have acquired the lock and the cache is missing.
+        Rails.logger.info "Cache miss for key #{key}"
+
+        rate_client = RateApiClient.new
+        rate_value = rate_client.fetch_rate(period: period, hotel: hotel, room: room)
+        
+        # Track actual API calls (not cache hits), only if the rate is successfully fetched
+        # Ruby treats nil as false, but 0 as true unlike JavaScript.
+        if (rate_value)
+            repo.increment("rate_api:calls")
+        end
+
+        # Cache for 5 minutes
+        repo.set(key, 300, rate_value.to_json)
+
+        # Add the key to the set of cached rate keys for background auto-refresh
+        repo.add_to_set("rate_cache_keys", key)
+
+        rate_value
+      end
+    end
+
+    # Check if we successfully acquired the lock and got a result
+    if result
+      result
+    else
+      # Failed to acquire lock. This should not happen often.
+      # Return a 503 Service Unavailable to indicate temporary unavailability
+      Rails.logger.warn "Service temporarily unavailable. Failed to fetch rate for #{key}"
+      raise ServiceUnavailableError.new("Service temporarily unavailable. Please retry.")
+    end
+  end
+
+  # Get the current count of all API calls (cache hits and misses)
+  def self.get_hit_count
+    RedisRepository.instance.get_counter("hit_count")
+  end
+
+  # Increment the count of all API calls (cache hits and misses)
+  def self.increment_hit_count
+    RedisRepository.instance.increment("hit_count")
+  end
+
+  # Get the set of all cached rate keys
+  def self.get_cached_rate_keys
+    RedisRepository.instance.get_set_members("rate_cache_keys")
+  end
+
+  private
+
+  # Get the key for the query for hotel room rate. Used to store the query in Redis.
+  # The JSON fields order is fixed, so the key is always the same for the same query.
+  # i.e. period --> hotel --> room
+  def self.get_hotel_room_query_key(period:, hotel:, room:)
+    { period: period, hotel: hotel, room: room }.to_json
+  end
+
+  # Get the current count of actual API calls made (not cache hits)
+  def self.get_api_call_count
+    RedisRepository.instance.get_counter("rate_api:calls")
+  end
+
+  # Get the remaining quota for calling the API
+  # Returns how many more API calls can be made before hitting the limit
+  def self.remaining_quota
+    AppSettings.rate_api_quota - get_api_call_count
+  end
+
+  # Check if quota is remaining (positive)
+  def self.has_quota_remaining?
+    remaining_quota > 0
+  end
+
+  # Custom error for service unavailable situations
+  class ServiceUnavailableError < StandardError
+    attr_reader :message
+
+    def initialize(message)
+      @message = message
+      super(message)
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Added Rate API client and service with Redis caching and quota management, plus enhanced health endpoint with metrics.

### What changed?

- Created `RateApiClient` class to handle communication with the external Rate API
- Implemented `RateApiService` with cache stampede prevention and quota tracking
- Enhanced the health endpoint (`HealthzController`) to include Rate API metrics:
  - Current quota
  - API calls used
  - Remaining quota
  - Whether quota is remaining
  - Total hit count
- Simplified Redis health check in the health endpoint

### How to test?

1. Check the `/healthz` endpoint to verify it shows the new metrics
2. Test the Rate API service by making requests that should use the cache
3. Verify quota tracking works by making multiple requests and checking the metrics

### Why make this change?

This change improves reliability and performance by:
- Preventing cache stampedes with distributed locking
- Tracking and managing API quota to avoid service disruptions
- Providing better observability through enhanced health metrics
- Adding proper error handling for API communication failures

The implementation ensures we can efficiently fetch rates while maintaining service availability even when the external Rate API is under high load or temporarily unavailable.