### PR TITLE
feat: Pricing Controller with Rate API Service

### DIFF
--- a/dynamic-pricing/app/services/problem_details.rb
+++ b/dynamic-pricing/app/services/problem_details.rb
@@ -5,9 +5,8 @@
 #
 # This creates a JSON-serializable Hash shaped like:
 # {
-#   "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+#   "type": "https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1",
 #   "title": "One or more validation errors occurred.",
-#   "status": 400,
 #   "traceId": "...optional trace id...",
 #   "instance": "/path/of/request",
 #   "errors": {
@@ -16,22 +15,32 @@
 # }
 #
 # Notes:
-# - We default the RFC 7231 400 reference into `type` for client error semantics, matching
-#   common conventions for validation failures.
 # - `errors` is a map of field name -> array of human-readable messages.
-# - The hash is intentionally not frozen so Rails can safely serialize it.
-module ValidationProblem
+module ProblemDetails
   module_function
 
-  DEFAULT_TYPE_FOR_400 = 'https://tools.ietf.org/html/rfc7231#section-6.5.1'.freeze
+  DEFAULT_TYPE_FOR_400 = 'https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.1'.freeze
   DEFAULT_VALIDATION_TITLE = 'One or more validation errors occurred.'.freeze
+  DEFAULT_TYPE_FOR_503 = 'https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4'.freeze
+  DEFAULT_SERVICE_UNAVAILABLE_TITLE = 'Service Temporarily Unavailable'.freeze
 
-  def build_validation_error(errors:, status: 400, title: DEFAULT_VALIDATION_TITLE, type: DEFAULT_TYPE_FOR_400, instance: nil, trace_id: nil)
+  def validation_error(errors:, title: DEFAULT_VALIDATION_TITLE, type: DEFAULT_TYPE_FOR_400, instance: nil, trace_id: nil)
     problem = {
       type: type,
       title: title,
-      status: status,
       errors: errors
+    }
+
+    problem[:instance] = instance if instance
+    problem[:traceId] = trace_id if trace_id
+
+    problem
+  end
+
+  def service_unavailable_error(title: DEFAULT_SERVICE_UNAVAILABLE_TITLE, type: DEFAULT_TYPE_FOR_503, instance: nil, trace_id: nil)
+    problem = {
+      type: type,
+      title: title,
     }
 
     problem[:instance] = instance if instance


### PR DESCRIPTION
### TL;DR

Implemented the dynamic pricing functionality by integrating with the RateApiService and added proper error handling.

### What changed?

- Replaced the placeholder rate response with actual implementation that fetches rates from RateApiService
- Added error handling for service unavailability
- Renamed `ValidationProblem` to `ProblemDetails` and expanded its functionality
- Added a new method `service_unavailable_error` to handle 503 errors
- Updated the RFC URL references to use datatracker.ietf.org
- Removed the redundant `status` field from problem details responses
- Enhanced tests to verify actual rate values from Redis cache

### How to test?

1. Make a valid request to `/pricing` with proper parameters:
   ```
   GET /pricing?period=Summer&hotel=FloatingPointResort&room=SingletonRoom
   ```
2. Verify the response contains a valid rate from the RateApiService
3. Test error scenarios:
   - Invalid parameters should return validation errors
   - When RateApiService is unavailable, it should return a 503 error

### Why make this change?

This completes the implementation of the dynamic pricing endpoint, which was previously returning a hardcoded value. The proper integration with RateApiService allows for actual dynamic pricing based on the provided parameters, while also handling error cases appropriately according to HTTP standards.