### PR TITLE
fix: enable running the app in docker without mounting volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,19 +14,22 @@ services:
     depends_on:
       - rate-api
       - valkey
+    restart: always
 
   rate-api:
     image: tripladev/rate-api:latest
     container_name: rate-api
     ports:
       - "8080:8080"
-
+    restart: always
+    
   valkey:
     image: valkey/valkey:latest
     container_name: valkey
     ports:
       - "6379:6379"
-
+    restart: always
+    
   redisinsight:
     image: redis/redisinsight:latest
     container_name: redisinsight
@@ -39,6 +42,25 @@ services:
       - redisinsight:/data
     depends_on:
       - valkey
+    restart: always
+
+  # worker-service refresh the rates in the background every 2 minutes
+  # unfortunately, because the worker-service is run with rake
+  # it does not have a hot reload mechanism unlike the app service
+  # if you make modifications to the logic, you will need to rebuild the image
+  # and restart the container
+  worker-service:
+    image: dynamic-pricing-proxy
+    container_name: worker-service
+    environment:
+      - REDIS_URL=redis://valkey:6379/0
+      - RATE_API_URL=http://rate-api:8080
+      - RATE_API_TOKEN=04aa6f42aa03f220c2ae9a276cd68c62
+      - RATE_API_QUOTA=1000
+    depends_on:
+      - app
+    command: bundle exec rake worker_service:run
+    restart: always
 
 volumes:
   redisinsight:

--- a/dynamic-pricing/.dockerignore
+++ b/dynamic-pricing/.dockerignore
@@ -15,20 +15,11 @@
 /config/credentials/*.key
 
 # Ignore all logfiles and tempfiles.
-/log/*
-/tmp/*
-!/log/.keep
-!/tmp/.keep
-
-# Ignore pidfiles, but keep the directory.
-/tmp/pids/*
-!/tmp/pids/.keep
+/log
+/tmp
 
 # Ignore storage (uploaded files in development and any SQLite databases).
 /storage/*
-!/storage/.keep
-/tmp/storage/*
-!/tmp/storage/.keep
 
 # Development specific ignores
 node_modules/
@@ -41,7 +32,9 @@ yarn-error.log*
 .idea/
 *.swp
 *.swo
-*~
+
+# Ignore keep files, these files are needed to keep the directory structure
+!*.keep
 
 # OS generated files
 .DS_Store

--- a/dynamic-pricing/.gitignore
+++ b/dynamic-pricing/.gitignore
@@ -12,22 +12,14 @@
 !/.env*.erb
 
 # Ignore all logfiles and tempfiles.
-/log/*
-/tmp/*
-!/log/.keep
-!/tmp/.keep
-
-# Ignore pidfiles, but keep the directory.
-/tmp/pids/*
-!/tmp/pids/
-!/tmp/pids/.keep
+/log
+/tmp
 
 # Ignore storage (uploaded files in development and any SQLite databases).
 /storage/*
-!/storage/.keep
-/tmp/storage/*
-!/tmp/storage/
-!/tmp/storage/.keep
+
+# Ignore keep files, these files are needed to keep the directory structure
+!*.keep
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key

--- a/dynamic-pricing/Dockerfile
+++ b/dynamic-pricing/Dockerfile
@@ -27,6 +27,9 @@ RUN apk add --no-cache \
 COPY Gemfile Gemfile.lock /rails/
 RUN bundle install --gemfile=/rails/Gemfile
 
+# Copy application source code
+COPY . /rails
+
 # Start the server by default, this can be overwritten at runtime
 EXPOSE 3000
 CMD ["sh", "-c", "./bin/rails db:prepare && ./bin/rails server -b 0.0.0.0"]

--- a/dynamic-pricing/app/controllers/healthz_controller.rb
+++ b/dynamic-pricing/app/controllers/healthz_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HealthzController < ApplicationController
     def index
         render json: {


### PR DESCRIPTION
### TL;DR

Added a worker service to refresh rates in the background and configured all services to restart automatically.

### What changed?

- Added `restart: always` configuration to all services in `docker-compose.yml`
- Added a new `worker-service` that refreshes rates every 2 minutes
- Simplified `.dockerignore` and `.gitignore` files by removing redundant patterns
- Updated the Dockerfile to copy the application source code
- Added `frozen_string_literal: true` to the `healthz_controller.rb`

### How to test?

1. Start the application with `docker-compose up`
2. Verify that the worker service is running with `docker ps`
3. Check the logs to confirm that rates are being refreshed every 2 minutes
4. Test that services automatically restart by manually stopping one (e.g., `docker stop rate-api`) and verifying it comes back up

### Why make this change?

This change improves the reliability of the application by ensuring services automatically restart after failures. The new worker service provides a background process to keep rates up-to-date without manual intervention, enhancing the application's functionality. The Dockerfile and ignore file updates improve the build process and maintainability.