### PR TITLE
feat: worker service

### DIFF
--- a/dynamic-pricing/app/services/rate_api_service.rb
+++ b/dynamic-pricing/app/services/rate_api_service.rb
@@ -46,7 +46,7 @@ class RateApiService
         # Track actual API calls (not cache hits), only if the rate is successfully fetched
         # Ruby treats nil as false, but 0 as true unlike JavaScript.
         if (rate_value)
-            repo.increment("rate_api:calls")
+            increment_api_call_count()
         end
 
         # Cache for 5 minutes
@@ -85,6 +85,82 @@ class RateApiService
     RedisRepository.instance.get_set_members("rate_cache_keys")
   end
 
+  # Refresh all cached rate keys by fetching them in batch and updating cache
+  # This method uses the RateApiClient's batch processing capability for efficiency
+  # @return [Hash] Summary of refresh operation: { updated: count, errors: count }
+  def self.refresh_all_cached_rates
+    repo = RedisRepository.instance
+    cached_keys = get_cached_rate_keys
+
+    if cached_keys.empty?
+      Rails.logger.info "No cached rate keys found to refresh"
+      return { updated: 0, errors: 0 }
+    end
+
+    Rails.logger.info "Refreshing #{cached_keys.length} cached rate keys"
+
+    # Parse all cached keys back to request objects
+    requests = []
+    cached_keys.each do |key|
+      begin
+        parsed_key = JSON.parse(key)
+        requests << {
+          period: parsed_key['period'],
+          hotel: parsed_key['hotel'],
+          room: parsed_key['room']
+        }
+      rescue JSON::ParserError => e
+        Rails.logger.warn "Failed to parse cached key: #{key}, error: #{e.message}"
+      end
+    end
+
+    return { updated: 0, errors: requests.length } if requests.empty?
+
+    # Fetch all rates in batch using the API client's batch processing
+    rate_client = RateApiClient.new
+    rates_dict = rate_client.fetch_rates(requests)
+
+    if rates_dict.empty?
+      Rails.logger.warn "Failed to fetch rates for refresh operation"
+      return { updated: 0, errors: requests.length }
+    end
+
+    # We successfully fetched the rates
+    increment_api_call_count()
+    # Update cache for each successfully fetched rate
+    updated_count = 0
+    error_count = 0
+
+    cached_keys.each do |key|
+      begin
+        parsed_key = JSON.parse(key)
+        period = parsed_key['period']
+        hotel = parsed_key['hotel']
+        room = parsed_key['room']
+
+        # Extract rate from nested dictionary
+        if rates_dict.key?(period) &&
+           rates_dict[period].key?(hotel) &&
+           rates_dict[period][hotel].key?(room)
+          rate_value = rates_dict[period][hotel][room]
+
+          # Update cache with new rate
+          repo.set(key, 300, rate_value.to_json)
+          updated_count += 1
+        else
+          Rails.logger.warn "Rate not found in response for #{period}/#{hotel}/#{room}"
+          error_count += 1
+        end
+      rescue JSON::ParserError => e
+        Rails.logger.warn "Failed to parse cached key during update: #{key}, error: #{e.message}"
+        error_count += 1
+      end
+    end
+
+    Rails.logger.info "Rate refresh completed: #{updated_count} updated, #{error_count} errors"
+    { updated: updated_count, errors: error_count }
+  end
+
   private
 
   # Get the key for the query for hotel room rate. Used to store the query in Redis.
@@ -92,6 +168,11 @@ class RateApiService
   # i.e. period --> hotel --> room
   def self.get_hotel_room_query_key(period:, hotel:, room:)
     { period: period, hotel: hotel, room: room }.to_json
+  end
+
+  # Increment the count of actual API calls made (not cache hits)
+  def self.increment_api_call_count
+    RedisRepository.instance.increment("rate_api:calls")
   end
 
   # Get the current count of actual API calls made (not cache hits)

--- a/dynamic-pricing/lib/tasks/worker_service.rake
+++ b/dynamic-pricing/lib/tasks/worker_service.rake
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+STDOUT.sync = true  # flush each write immediately
+
+# Rake task namespace for logging utilities
+namespace :worker_service do
+  # Description for the task that appears in rake -T output
+  desc "Start the worker service"
+
+  task :run => :environment do
+    Rails.logger.info "This task will start the worker service. Press Ctrl+C to stop."
+    Rails.logger.info "Loading Rails environment..."
+
+    loop do
+      RateApiService.refresh_all_cached_rates
+
+      # Sleep for 120 seconds (2 minutes)
+      sleep 120
+    end
+  end
+end


### PR DESCRIPTION
### TL;DR

Added a background worker service to refresh cached rates and refactored API call tracking.

### What changed?

- Added `refresh_all_cached_rates` method to `RateApiService` that efficiently refreshes all cached rates in a single batch operation
- Extracted API call tracking into a separate `increment_api_call_count` method
- Created a new Rake task `worker_service:run` that periodically refreshes cached rates every 2 minutes

### How to test?

1. Run the worker service with `rake worker_service:run`
2. Verify in logs that cached rates are being refreshed every 2 minutes
3. Check Redis to confirm that cached rates are being updated
4. Verify that API call counts are still being tracked correctly

### Why make this change?

This change improves the system's reliability by proactively refreshing cached rates before they expire. By using batch processing, we reduce the number of API calls needed compared to on-demand refreshing, which helps with both performance and staying within API rate limits. The worker service ensures that users consistently get up-to-date pricing data without experiencing cache misses.