### PR TITLE
fix: sentry error in worker service

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,10 @@
 {
-    "kiroAgent.configureMCP": "Disabled"
+	"files.associations": {
+		"*.css": "tailwindcss"
+	},
+	"tailwindCSS.classFunctions": [
+		"tx",
+		"tv"
+	],
+	"typescript.preferences.preferTypeOnlyAutoImports": true
 }

--- a/dynamic-pricing/config/initializers/sentry.rb
+++ b/dynamic-pricing/config/initializers/sentry.rb
@@ -15,17 +15,14 @@ Sentry.init do |config|
   # see https://docs.sentry.io/platforms/ruby/data-management/data-collected/ for more info
   config.send_default_pii = true
 
-  # Enable sending logs to Sentry
-  config.enable_logs = true
-  # Patch Ruby logger to forward logs
-  config.enabled_patches = [:logger]
+  # Disable sending all logs to Sentry to reduce noise
+  config.enable_logs = false
+  # Don't patch logger to avoid forwarding all logs
+  # config.enabled_patches = [:logger]
+  config.enabled_patches = []
 
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for tracing.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 1.0
-  # or
-  config.traces_sampler = lambda do |context|
-    true
-  end
+  config.traces_sample_rate = 0
 end

--- a/dynamic-pricing/lib/tasks/worker_service.rake
+++ b/dynamic-pricing/lib/tasks/worker_service.rake
@@ -48,7 +48,7 @@ namespace :worker_service do
         Sentry.capture_exception(e)
       ensure
         # Always finish the transaction
-        transaction.finish
+        transaction&.finish
       end
 
       # Sleep for 120 seconds (2 minutes)


### PR DESCRIPTION
### TL;DR

Reduced Sentry noise and improved VS Code configuration for the project.

### What changed?

- Updated VS Code settings to support Tailwind CSS and TypeScript type-only imports
- Reduced Sentry logging by:
  - Disabling automatic log forwarding to Sentry
  - Setting traces_sample_rate to 0 (from 1.0)
  - Removing the traces_sampler function
- Fixed a potential null reference issue in the worker service by adding a safe navigation operator to `transaction&.finish`

### How to test?

1. Verify VS Code properly recognizes Tailwind CSS files and functions
2. Check that Sentry is no longer receiving all logs from the application
3. Run the worker service and verify it handles cases where the transaction might be null

### Why make this change?

The Sentry configuration was generating too much noise by sending all logs and capturing 100% of transactions. This change reduces unnecessary data being sent to Sentry while maintaining error tracking capabilities. The VS Code settings improvements enhance the developer experience, and the null check in the worker service prevents potential runtime errors.