### PR TITLE
feat: publish github image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'dynamic-pricing/**'
+      - '.github/workflows/docker-publish.yml'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/dynamic-pricing-proxy
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./dynamic-pricing
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/dynamic-pricing-ui/src/app/HealthMetrics.tsx
+++ b/dynamic-pricing-ui/src/app/HealthMetrics.tsx
@@ -133,7 +133,7 @@ export function HealthMetrics() {
 								</div>
 								<div className="text-center">
 									<div className="text-2xl font-bold text-purple-600">
-										{healthData.metrics.hit_count}
+										{Number(healthData.metrics.hit_count).toLocaleString()}
 									</div>
 									<div className="text-sm text-gray-500">
 										Hit Count


### PR DESCRIPTION
# Add Docker Image Publishing Workflow and Improve Documentation

### TL;DR

Added GitHub Actions workflow to automatically build and publish the Dynamic Pricing Proxy Docker image to GitHub Packages, enhanced API documentation, and improved number formatting in the UI.

### What changed?

- Added `.github/workflows/docker-publish.yml` to automatically build and publish Docker images when changes are pushed to the main branch
- Enhanced the README with detailed Docker image usage instructions and expanded API documentation with RFC-compliant response examples
- Added number formatting to the hit count display in the HealthMetrics component to improve readability of large numbers
- Added a reference to the dashboard screenshot in the documentation

### How to test?

1. Push changes to the main branch to trigger the Docker image build workflow
2. Pull and run the published image:
   ```bash
   docker pull ghcr.io/{owner}/mitsu/dynamic-pricing-proxy:latest
   docker run -p 3000:3000 ghcr.io/{owner}/mitsu/dynamic-pricing-proxy:latest
   ```
3. Verify the hit count formatting in the UI by generating a large number of requests

### Why make this change?

This change streamlines deployment by automating the Docker image build process, making it easier for users to run the application without building from source. The improved documentation provides clearer guidance on API responses and Docker usage, while the UI enhancement makes high traffic metrics more readable.