### PR TITLE
feat: make back-end compatible with reverse proxy

### DIFF
--- a/dynamic-pricing/config/environments/development.rb
+++ b/dynamic-pricing/config/environments/development.rb
@@ -48,6 +48,8 @@ Rails.application.configure do
   # Highlight code that enqueued background job in logs.
   config.active_job.verbose_enqueue_logs = true
 
+  # Allow all hosts, as the application will be served through a reverse proxy
+  config.hosts.clear
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/dynamic-pricing/config/environments/production.rb
+++ b/dynamic-pricing/config/environments/production.rb
@@ -71,11 +71,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  # Allow all hosts, as the application will be served through a reverse proxy
+  config.hosts.clear
+
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
### TL;DR

Allow the application to be served through a reverse proxy by clearing host restrictions in both development and production environments.

### What changed?

- Added `config.hosts.clear` in the development environment configuration
- Added `config.hosts.clear` in the production environment configuration, replacing the commented-out host restriction example

### How to test?

1. Run the application behind a reverse proxy in development or production environment
2. Verify that requests are properly handled without host validation errors
3. Confirm the application can be accessed through different hostnames or IP addresses

### Why make this change?

The application needs to be served through a reverse proxy, which may use different hostnames or IP addresses than what would normally be allowed by Rails' default host filtering. By clearing the host restrictions, we ensure the application can accept requests from any hostname, which is necessary when operating behind a proxy that may modify the Host header.